### PR TITLE
Run codecov at end of CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
             . venv/bin/activate
             python -m mypy octopart --ignore-missing-imports
 
+      - run:
+          name: Run codecov
+          command: |
+            pip install codecov
+            codecov
+
       - run: mkdir -p test-reports
 
       - store_test_results:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Python Client for Octopart API v3
 =================================
 
 [![CircleCI](https://circleci.com/gh/tempoautomation/octopart.svg?style=svg&circle-token=aee3e352a57741869fc0d3a62a18d64b8f4f23f9)](https://circleci.com/gh/tempoautomation/octopart)
+[![codecov](https://codecov.io/gh/tempoautomation/octopart/branch/master/graph/badge.svg)](https://codecov.io/gh/tempoautomation/octopart)
 
 
 # Quickstart


### PR DESCRIPTION
Adds [codecov.io](https://codecov.io/) coverage to the CI build and its badge to the README.